### PR TITLE
Decode resolved values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
   </scm>
 
     <properties>
-        <java.version>1.8</java.version>
-        <spring-web.version>5.2.9.RELEASE</spring-web.version>
-        <spring-hateoas.version>1.1.2.RELEASE</spring-hateoas.version>
+        <java.version>17</java.version>
+        <spring-web.version>6.2.1</spring-web.version>
+        <spring-hateoas.version>2.4.1</spring-hateoas.version>
         <junit.version>4.12</junit.version>
-        <mockito-all.version>1.8.5</mockito-all.version>
+        <mockito-all.version>5.15.2</mockito-all.version>
     </properties>
 
     <dependencies>
@@ -63,7 +63,13 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-all.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito-all.version}</version>
             <scope>test</scope>
         </dependency>
@@ -75,9 +81,9 @@
             <!--<scope>test</scope>-->
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/rocks/spiffy/spring/hateoas/utils/link/AbstractResourceLinkFactory.java
+++ b/src/main/java/rocks/spiffy/spring/hateoas/utils/link/AbstractResourceLinkFactory.java
@@ -40,7 +40,7 @@ public abstract class AbstractResourceLinkFactory<R> implements ResourceLinkFact
         final Optional<Link> optionalLink;
 
         if(uriForIdentifier.isPresent()) {
-            Link link = new Link(uriForIdentifier.get().toString());
+            Link link = Link.of(uriForIdentifier.get().toString());
             optionalLink = Optional.of(link);
         } else {
             optionalLink = Optional.empty();

--- a/src/main/java/rocks/spiffy/spring/hateoas/utils/uri/resolver/ControllerUriResolver.java
+++ b/src/main/java/rocks/spiffy/spring/hateoas/utils/uri/resolver/ControllerUriResolver.java
@@ -1,12 +1,14 @@
 package rocks.spiffy.spring.hateoas.utils.uri.resolver;
 
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.util.UriTemplate;
-
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriTemplate;
+import org.springframework.web.util.UriUtils;
 
 /**
  * Provides an easy way of getting request parameters out of a uri
@@ -39,7 +41,7 @@ public class ControllerUriResolver {
      * @return Resolve the map of template variables
      */
     public Map<String, String> resolve(String uri) {
-        return uriTemplate.match(uri);
+        return match(uri);
     }
 
     /**
@@ -50,7 +52,7 @@ public class ControllerUriResolver {
      * @return optionally the named uri parameter value if found
      */
     public Optional<String> resolve(String uri, String parameterToResolve) {
-        Map<String, String> match = uriTemplate.match(uri);
+        Map<String, String> match = match(uri);
 
         final Optional<String> matchFound;
 
@@ -88,5 +90,12 @@ public class ControllerUriResolver {
 
     public MethodInvocation getInvocation() {
         return invocation;
+    }
+
+    private Map<String, String> match(String uri) {
+        Map<String, String> match = new HashMap<>();
+        uriTemplate.match(uri)
+                .forEach((key, value) -> match.put(key, UriUtils.decode(value, StandardCharsets.UTF_8)));
+        return match;
     }
 }

--- a/src/test/java/rocks/spiffy/spring/hateoas/utils/resource/ExtendedResourceSupportTest.java
+++ b/src/test/java/rocks/spiffy/spring/hateoas/utils/resource/ExtendedResourceSupportTest.java
@@ -1,17 +1,17 @@
 package rocks.spiffy.spring.hateoas.utils.resource;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.springframework.hateoas.Link;
-import org.springframework.hateoas.LinkRelation;
-
-import java.util.Map;
-import java.util.Optional;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
 
 /**
  * @author Andrew Hill
@@ -24,7 +24,7 @@ public class ExtendedResourceSupportTest {
         ExtendedRepresentationModel e = new ExtendedRepresentationModel();
         String mockUri = "http://spam.spam:9090";
 
-        Link link = new Link(mockUri, "spam");
+        Link link = Link.of(mockUri, "spam");
         
         e.add(link);
 

--- a/src/test/java/rocks/spiffy/spring/hateoas/utils/uri/builder/ControllerUriBuilderTest.java
+++ b/src/test/java/rocks/spiffy/spring/hateoas/utils/uri/builder/ControllerUriBuilderTest.java
@@ -1,24 +1,25 @@
 package rocks.spiffy.spring.hateoas.utils.uri.builder;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.hateoas.Link;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import rocks.spiffy.spring.hateoas.utils.DummyController;
 import rocks.spiffy.spring.hateoas.utils.uri.resolver.ControllerUriResolver;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 /**
  * @author Andrew Hill
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ControllerUriBuilderTest
 {
     @Mock

--- a/src/test/java/rocks/spiffy/spring/hateoas/utils/uri/resolver/ControllerUriResolverTest.java
+++ b/src/test/java/rocks/spiffy/spring/hateoas/utils/uri/resolver/ControllerUriResolverTest.java
@@ -1,22 +1,25 @@
 package rocks.spiffy.spring.hateoas.utils.uri.resolver;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import rocks.spiffy.spring.hateoas.utils.DummyController;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 /**
  * @author Andrew Hill
@@ -131,5 +134,18 @@ public class ControllerUriResolverTest
         assertThat(pathVariables.get(1).value(), is("petName"));
     }
 
+    @Test
+    public void testSingleParameterWithEncodedValueFound() {
+        //given
+        String uri = WebMvcLinkBuilder.linkTo(methodOn(DummyController.class).findOne("hello:world")).toUri().toString();
+
+        //when
+        Map<String, String> params = ControllerUriResolver.on(
+                methodOn(DummyController.class).findOne(null)).resolve(uri);
+
+        //then
+        assertThat(params.size(), is(1));
+        assertThat(params.get("identifier"), is("hello:world"));
+    }
 
 }


### PR DESCRIPTION
Fix #21

Since https://github.com/spring-projects/spring-hateoas/commit/8c4824245e6df47407209403a8516fd66444c77f, Spring HATEOAS `WebMvcLinkBuilder#linkTo`  uses https://github.com/spring-projects/spring-hateoas/blob/b19f7de6d329f728e09cbb294c753ffd6c1d5d50/src/main/java/org/springframework/hateoas/TemplateVariable.java#L526 .

Characters considered as special or forbidden by Spring are encoded. 

With this PR, resolving a uri created by `WebMvcLinkBuilder#linkTo` decode encoded values. 

The encoding behaviour was introduced in Spring HATEOAS 1.4.0. But it was changed since. Therefore, IMO, the easier way is to upgrade the current project to the latest Spring HATEOAS version which implies moving to Java level 17 and the jakarta namespace. That's what this PR does.